### PR TITLE
Pt159251141 Feedback-Remove placeholders

### DIFF
--- a/UI/add.html
+++ b/UI/add.html
@@ -68,7 +68,7 @@
                                             <label class="white-text">Title:</label>
                                         </div>
                                         <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                            <input type="text" required="true" class="control-form" id="title" placeholder="Enter Title" autocomplete="title" />
+                                            <input type="text" required="true" class="control-form" id="title" autocomplete="title" />
                                         </div>
                                     </div>
                                     <div class="field grid-container">
@@ -76,7 +76,7 @@
                                             <label class="white-text">Description:</label>
                                         </div>
                                         <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                            <textarea class="control-form" id="description" required="true" placeholder="Write more about it..." resize="no"></textarea>
+                                            <textarea class="control-form" id="description" required="true" resize="no"></textarea>
                                         </div>
                                     </div>
                                     <div class="field grid-container">

--- a/UI/edit-profile.html
+++ b/UI/edit-profile.html
@@ -66,7 +66,7 @@
                                             <label class="">Full Name:</label>
                                         </div>
                                         <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                            <input type="text" required="true" class="control-form" id="signup_fullname" placeholder="Enter Fullname" autocomplete="name" value="Runor Adjekpiyede" />
+                                            <input type="text" required="true" class="control-form" id="signup_fullname" autocomplete="name" value="Runor Adjekpiyede" />
                                         </div>
                                     </div>
                                     <div class="field grid-container">
@@ -74,7 +74,7 @@
                                             <label class="">Email Address:</label>
                                         </div>
                                         <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                            <input type="email" required="true" class="control-form" id="signup_email" placeholder="Enter Email Address" autocomplete="email" value="kamp@example.com" />
+                                            <input type="email" required="true" class="control-form" id="signup_email" autocomplete="email" value="kamp@example.com" />
                                         </div>
                                     </div>
                                     <div class="field grid-container">
@@ -82,7 +82,7 @@
                                             <label class="">Date of Birth:</label>
                                         </div>
                                         <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                            <input type="date" class="control-form" id="signup_username" placeholder="Enter Username" autocomplete="date" value="" pattern="[a-z|A-Z|\d]{1,15}" />
+                                            <input type="date" class="control-form" id="signup_username" autocomplete="date" value="" pattern="[a-z|A-Z|\d]{1,15}" />
                                         </div>
                                     </div>
                                     <div class="field grid-container">

--- a/UI/edit.html
+++ b/UI/edit.html
@@ -68,7 +68,7 @@
                                             <label class="white-text">Title:</label>
                                         </div>
                                         <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                            <input type="text" required="true" class="control-form" id="title" placeholder="Enter Title" autocomplete="title" value="Where can I get some?" />
+                                            <input type="text" required="true" class="control-form" id="title" autocomplete="title" value="Where can I get some?" />
                                         </div>
                                     </div>
                                     <div class="field grid-container">
@@ -76,7 +76,7 @@
                                             <label class="white-text">Description:</label>
                                         </div>
                                         <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                            <textarea class="control-form" id="description" required="true" placeholder="Write more about it..." resize="no">There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum generators on the Internet tend to repeat predefined chunks as necessary, making this the first true generator on the Internet. It uses a dictionary of over 200 Latin words, combined with a handful of model sentence structures, to generate Lorem Ipsum which looks reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic words etc.</textarea>
+                                            <textarea class="control-form" id="description" required="true" resize="no">There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum generators on the Internet tend to repeat predefined chunks as necessary, making this the first true generator on the Internet. It uses a dictionary of over 200 Latin words, combined with a handful of model sentence structures, to generate Lorem Ipsum which looks reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic words etc.</textarea>
                                         </div>
                                     </div>
                                     <div class="field grid-container">

--- a/UI/signin.html
+++ b/UI/signin.html
@@ -65,7 +65,7 @@
                                     <label class="white-text">Email Address</label>
                                 </div>
                                 <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                    <input type="email" required="true" class="control-form" id="signup_email" placeholder="Enter Email Address" autocomplete="email" />
+                                    <input type="email" required="true" class="control-form" id="signup_email" autocomplete="email" />
                                 </div>
                             </div>
                             <div class="field grid-container">
@@ -73,7 +73,7 @@
                                     <label class="white-text">Password</label>
                                 </div>
                                 <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                    <input type="password" required="true" class="control-form" id="signup_password" placeholder="Enter Password" autocomplete="password" />
+                                    <input type="password" required="true" class="control-form" id="signup_password" autocomplete="password" />
                                 </div>
                             </div>
 							<div class="field grid-container">

--- a/UI/signup.html
+++ b/UI/signup.html
@@ -65,7 +65,7 @@
                                     <label class="white-text">Full Name:</label>
                                 </div>
                                 <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                    <input type="text" required="true" class="control-form" id="signup_fullname" placeholder="Enter Fullname" autocomplete="name" />
+                                    <input type="text" required="true" class="control-form" id="signup_fullname" autocomplete="name" />
                                 </div>
                             </div>
                             <div class="field grid-container">
@@ -73,7 +73,7 @@
                                     <label class="white-text">Email Address</label>
                                 </div>
                                 <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                    <input type="email" required="true" class="control-form" id="signup_email" placeholder="Enter Email Address" autocomplete="email" />
+                                    <input type="email" required="true" class="control-form" id="signup_email" autocomplete="email" />
                                 </div>
                             </div>
                             <div class="field grid-container">
@@ -81,7 +81,7 @@
                                     <label class="white-text">Date of Birth</label>
                                 </div>
                                 <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                    <input type="date" class="control-form" id="date_of_birth" placeholder="Enter Date of Birth" autocomplete="date_of_birth" required="true" pattern="[a-z|A-Z|\d]{1,15}" />
+                                    <input type="date" class="control-form" id="date_of_birth" autocomplete="date_of_birth" required="true" pattern="[a-z|A-Z|\d]{1,15}" />
                                 </div>
                             </div>
                             <div class="field grid-container">
@@ -89,7 +89,7 @@
                                     <label class="white-text">Password</label>
                                 </div>
                                 <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                    <input type="password" required="true" class="control-form" id="signup_password" placeholder="Enter Password" autocomplete="password" />
+                                    <input type="password" required="true" class="control-form" id="signup_password" autocomplete="password" />
                                 </div>
                             </div>
 							<div class="field grid-container">
@@ -97,7 +97,7 @@
                                     <label class="white-text">Confirm Password</label>
                                 </div>
                                 <div class="col-4-6 col-6-6-md col-6-6-xs">
-                                    <input type="password" required="true" class="control-form" id="confirm_password" placeholder="Enter Password Again" autocomplete="password" />
+                                    <input type="password" required="true" class="control-form" id="confirm_password" autocomplete="password" />
                                 </div>
                             </div>
 							<div class="field grid-container">


### PR DESCRIPTION
What does this PR do?
The placeholders in the forms were no longer neccessary. This commit removes the placeholder from forms. 
Description of Task to be completed?
Removes the placeholder text from:
- sign in page
- sign up page
- new entry page
- edit entry page
- edit profile page

How should this be manually tested?
After cloning the repo, open signup.html from the UI folder in any browser of your choice, preferably chrome. You will see the placeholders have been removed.

Any background context you want to provide?
Only the forgot password page has a placeholder.

What are the relevant pivotal tracker stories?
Pt159251141
Screenshots (if appropriate)
Questions: